### PR TITLE
Encoder readings, speed writing, and smoothed position motion

### DIFF
--- a/Custom_Library/Dynamixel_Actuators/InitializeForPosition.m
+++ b/Custom_Library/Dynamixel_Actuators/InitializeForPosition.m
@@ -19,12 +19,12 @@ classdef InitializeForPosition < matlab.System ...
     
     properties
         
-        P_GAIN          = 400;
-        I_GAIN          = 0;
-        D_GAIN          = 200;
-        MAX_POSITION    = 3072;
-        MIN_POSITION    = 1024;
-        VELOCITY_LIMIT  = 0;
+        P_GAIN                = 400;
+        I_GAIN                = 0;
+        D_GAIN                = 200;
+        MAX_POSITION          = 3072;
+        MIN_POSITION          = 1024;
+        MOVE_TIME             = 0;
         
     end
     
@@ -53,7 +53,7 @@ classdef InitializeForPosition < matlab.System ...
                  coder.cinclude('dynamixel_sdk.h');
                  coder.cinclude('dynamixel_functions.h');
                  coder.ceval('initialize_dynamixel_position_control',obj.P_GAIN, obj.I_GAIN, ...
-                     obj.D_GAIN, obj.MAX_POSITION, obj.MIN_POSITION, obj.VELOCITY_LIMIT);
+                     obj.D_GAIN, obj.MAX_POSITION, obj.MIN_POSITION, obj.MOVE_TIME);
             end
         end
         
@@ -127,7 +127,8 @@ classdef InitializeForPosition < matlab.System ...
             header = matlab.system.display.Header('InitializeForPosition','Title',...
                 'Dynamixel Actuator - Initialize Position Control','Text',...
                 ['This simulink block initializes the actuators for position control. '...
-                'This block must be placed ONCE in the diagram, at the top level.' newline]);
+                'This block must be placed ONCE in the diagram, at the top level.'...
+                ' Move time indicates how many [ms] to spend moving, at a constant velocity, to the desired position' newline]);
         end
         
     end

--- a/Custom_Library/Dynamixel_Actuators/MoveArm_Speed.m
+++ b/Custom_Library/Dynamixel_Actuators/MoveArm_Speed.m
@@ -63,7 +63,9 @@ classdef MoveArm_Speed < matlab.System ...
                 % Place simulation termination code here
             else
                 % Call C-function implementing device termination
-                %coder.ceval('sink_terminate');
+                 coder.cinclude('dynamixel_sdk.h');
+                 coder.cinclude('dynamixel_functions.h');
+                 coder.ceval('command_dynamixel_speed',0, 0, 0); % send 0 speed at termination
             end
         end
     end

--- a/Custom_Library/Dynamixel_Actuators/include/dynamixel_functions.h
+++ b/Custom_Library/Dynamixel_Actuators/include/dynamixel_functions.h
@@ -1,7 +1,7 @@
 #include "rtwtypes.h"
 
 void initialize_dynamixel_position_control(double, double, double, double, double, double);
-void initialize_dynamixel_speed_control(double, double, double);
+void initialize_dynamixel_speed_control(double, double, double, double);
 void initialize_dynamixel_PWM_control(double);
 void initialize_dynamixel_current_control(double);
 void initialize_dynamixel_special_control(double, double, double, double, double, double, double);
@@ -12,6 +12,6 @@ void command_dynamixel_PWM(double, double, double);
 void command_dynamixel_current(int, int, int);
 void command_dynamixel_special(int, int, double);
 void command_dynamixel_arm_gripper_position(double, double, double, double, double, double, double);
-void read_dynamixel_position(double*, double*, double*);
+void read_dynamixel_position(double*, double*, double*, double*, double*, double*);
 void read_dynamixel_load(double*, double*, double*);
 void terminate_dynamixel();

--- a/Custom_Library/Dynamixel_Actuators/src/dynamixel_functions.cpp
+++ b/Custom_Library/Dynamixel_Actuators/src/dynamixel_functions.cpp
@@ -5,13 +5,16 @@
 #include <stdio.h>
 #include <tgmath.h> 
 
+// To do the modulus operator on doubles
+#include <cmath>
+
 // Include the dynamixel headers
 #include "dynamixel_sdk.h"
 #include "dynamixel_functions.h"
 
 // Define the device name, baudrate, and protocol
 #define DEVICENAME                      "/dev/ttyUSB0"
-#define BAUDRATE                        1
+#define BAUDRATE                        1000000
 #define PROTOCOL_VERSION                2.0
 
 // Control table addresses                
@@ -30,13 +33,14 @@
 #define ADDR_MX_MAX_POSITION            48
 #define ADDR_MX_MIN_POSITION            52
 #define ADDR_MX_VELOCITY_LIMIT          44
-#define ADDR_MX_ACCELERATION_LIMIT      40
+#define ADDR_MX_VELOCITY_PROFILE        112
 #define ADDR_MX_CURRENT_LIMIT           38
 #define ADDR_MX_RETURN_DELAY            9
 #define ADDR_MX_DRIVE_MODE              10
 #define ADDR_MX_OPERATING_MODE          11
 #define ADDR_MX_PWM_LIMIT               36
 #define ADDR_MX_GOAL_PWM                100
+#define ADDR_MX_PROFILE_ACCELERATION    108
 
 // Define the port handler and packet handler variables 
 dynamixel::PortHandler *portHandler = dynamixel::PortHandler::getPortHandler(DEVICENAME);
@@ -48,8 +52,12 @@ dynamixel::GroupBulkWrite groupBulkWrite(portHandler, packetHandler);
 // Initialize GroupBulkRead instance
 dynamixel::GroupBulkRead groupBulkRead(portHandler, packetHandler);
 
+// Initialize Groupsyncread instance for Present Speed & Position [first 4 are speed, next 4 are position, luckily the values are right beside each other in the control table]
+dynamixel::GroupSyncRead groupSyncRead(portHandler, packetHandler, ADDR_MX_PRESENT_SPEED, 8);
+
+
 void initialize_dynamixel_position_control(double P_GAIN, double I_GAIN, double D_GAIN, double MAX_POSITION,
-                                           double MIN_POSITION, double VELOCITY_LIMIT)
+                                           double MIN_POSITION, double MOVE_TIME)
 {
     
     // Define the transmission failure code
@@ -57,71 +65,89 @@ void initialize_dynamixel_position_control(double P_GAIN, double I_GAIN, double 
         
     // Open COM port for serial communication with the actuators
    portHandler->openPort();
+   
+    // Set port baudrate
+	portHandler->setBaudRate(BAUDRATE);
     
     // Initialize the dxl_error variable
     uint8_t dxl_error = 0;
     
     // Set up the motors for position control
     dxl_comm_result   = packetHandler->write1ByteTxRx(portHandler, 1, ADDR_MX_OPERATING_MODE, 3, &dxl_error);
+	dxl_comm_result   = packetHandler->write1ByteTxRx(portHandler, 1, ADDR_MX_DRIVE_MODE, 4, &dxl_error); // Velocity_profile yields the time required to reach goal position
     dxl_comm_result   = packetHandler->write2ByteTxRx(portHandler, 1, ADDR_MX_POSITION_P_GAIN, P_GAIN, &dxl_error);
     dxl_comm_result   = packetHandler->write2ByteTxRx(portHandler, 1, ADDR_MX_POSITION_I_GAIN, I_GAIN, &dxl_error);
     dxl_comm_result   = packetHandler->write2ByteTxRx(portHandler, 1, ADDR_MX_POSITION_D_GAIN, D_GAIN, &dxl_error);
     dxl_comm_result   = packetHandler->write4ByteTxRx(portHandler, 1, ADDR_MX_MAX_POSITION, MAX_POSITION, &dxl_error);
     dxl_comm_result   = packetHandler->write4ByteTxRx(portHandler, 1, ADDR_MX_MIN_POSITION, MIN_POSITION, &dxl_error);
-    dxl_comm_result   = packetHandler->write4ByteTxRx(portHandler, 1, ADDR_MX_VELOCITY_LIMIT, VELOCITY_LIMIT, &dxl_error);
+    dxl_comm_result   = packetHandler->write4ByteTxRx(portHandler, 1, ADDR_MX_VELOCITY_PROFILE, MOVE_TIME, &dxl_error);
+    dxl_comm_result   = packetHandler->write4ByteTxRx(portHandler, 1, ADDR_MX_PROFILE_ACCELERATION, 0, &dxl_error);
     dxl_comm_result   = packetHandler->write1ByteTxRx(portHandler, 1, ADDR_MX_TORQUE_ENABLE, 1, &dxl_error);
     
     dxl_comm_result   = packetHandler->write1ByteTxRx(portHandler, 2, ADDR_MX_OPERATING_MODE, 3, &dxl_error);
+	dxl_comm_result   = packetHandler->write1ByteTxRx(portHandler, 2, ADDR_MX_DRIVE_MODE, 4, &dxl_error); // Velocity_profile yields the time required to reach goal position
     dxl_comm_result   = packetHandler->write2ByteTxRx(portHandler, 2, ADDR_MX_POSITION_P_GAIN, P_GAIN, &dxl_error);
     dxl_comm_result   = packetHandler->write2ByteTxRx(portHandler, 2, ADDR_MX_POSITION_I_GAIN, I_GAIN, &dxl_error);
     dxl_comm_result   = packetHandler->write2ByteTxRx(portHandler, 2, ADDR_MX_POSITION_D_GAIN, D_GAIN, &dxl_error);
     dxl_comm_result   = packetHandler->write4ByteTxRx(portHandler, 2, ADDR_MX_MAX_POSITION, MAX_POSITION, &dxl_error);
     dxl_comm_result   = packetHandler->write4ByteTxRx(portHandler, 2, ADDR_MX_MIN_POSITION, MIN_POSITION, &dxl_error);
-    dxl_comm_result   = packetHandler->write4ByteTxRx(portHandler, 2, ADDR_MX_VELOCITY_LIMIT, VELOCITY_LIMIT, &dxl_error);
+    dxl_comm_result   = packetHandler->write4ByteTxRx(portHandler, 2, ADDR_MX_VELOCITY_PROFILE, MOVE_TIME, &dxl_error);
+    dxl_comm_result   = packetHandler->write4ByteTxRx(portHandler, 2, ADDR_MX_PROFILE_ACCELERATION, 0, &dxl_error);
     dxl_comm_result   = packetHandler->write1ByteTxRx(portHandler, 2, ADDR_MX_TORQUE_ENABLE, 1, &dxl_error);
     
     dxl_comm_result   = packetHandler->write1ByteTxRx(portHandler, 3, ADDR_MX_OPERATING_MODE, 3, &dxl_error);
+	dxl_comm_result   = packetHandler->write1ByteTxRx(portHandler, 3, ADDR_MX_DRIVE_MODE, 4, &dxl_error); // Velocity_profile yields the time required to reach goal position
     dxl_comm_result   = packetHandler->write2ByteTxRx(portHandler, 3, ADDR_MX_POSITION_P_GAIN, P_GAIN, &dxl_error);
     dxl_comm_result   = packetHandler->write2ByteTxRx(portHandler, 3, ADDR_MX_POSITION_I_GAIN, I_GAIN, &dxl_error);
     dxl_comm_result   = packetHandler->write2ByteTxRx(portHandler, 3, ADDR_MX_POSITION_D_GAIN, D_GAIN, &dxl_error);
     dxl_comm_result   = packetHandler->write4ByteTxRx(portHandler, 3, ADDR_MX_MAX_POSITION, MAX_POSITION, &dxl_error);
     dxl_comm_result   = packetHandler->write4ByteTxRx(portHandler, 3, ADDR_MX_MIN_POSITION, MIN_POSITION, &dxl_error);
-    dxl_comm_result   = packetHandler->write4ByteTxRx(portHandler, 3, ADDR_MX_VELOCITY_LIMIT, VELOCITY_LIMIT, &dxl_error);
+    dxl_comm_result   = packetHandler->write4ByteTxRx(portHandler, 3, ADDR_MX_VELOCITY_PROFILE, MOVE_TIME, &dxl_error);
+    dxl_comm_result   = packetHandler->write4ByteTxRx(portHandler, 3, ADDR_MX_PROFILE_ACCELERATION, 0, &dxl_error);
     dxl_comm_result   = packetHandler->write1ByteTxRx(portHandler, 3, ADDR_MX_TORQUE_ENABLE, 1, &dxl_error);
 
 }
 
-void initialize_dynamixel_speed_control(double P_GAIN, double I_GAIN, double VELOCITY_LIMIT )
+void initialize_dynamixel_speed_control(double P_GAIN, double I_GAIN, double VELOCITY_LIMIT, double ACCELERATION_TIME)
 {
 
     // Define the transmission failure code
-    int dxl_comm_result      = COMM_TX_FAIL;
-    bool dxl_addparam_result = false;
-    
+    int dxl_comm_result = COMM_TX_FAIL;
+
     // Initialize the dxl_error variable
     uint8_t dxl_error = 0;
-    
+
     // Open COM port for serial communication with the actuators
     portHandler->openPort();
-    
-    // Set up the motors for position control
-    dxl_comm_result   = packetHandler->write1ByteTxRx(portHandler, 1, ADDR_MX_OPERATING_MODE, 1, &dxl_error);
-    dxl_comm_result   = packetHandler->write2ByteTxRx(portHandler, 1, ADDR_MX_VELOCITY_P_GAIN, P_GAIN, &dxl_error);
-    dxl_comm_result   = packetHandler->write2ByteTxRx(portHandler, 1, ADDR_MX_VELOCITY_I_GAIN, I_GAIN, &dxl_error);
-    dxl_comm_result   = packetHandler->write4ByteTxRx(portHandler, 1, ADDR_MX_VELOCITY_LIMIT, VELOCITY_LIMIT, &dxl_error);
-    dxl_comm_result   = packetHandler->write1ByteTxRx(portHandler, 1, ADDR_MX_TORQUE_ENABLE, 1, &dxl_error);
-    
-    dxl_comm_result   = packetHandler->write1ByteTxRx(portHandler, 2, ADDR_MX_OPERATING_MODE, 1, &dxl_error);
-    dxl_comm_result   = packetHandler->write2ByteTxRx(portHandler, 2, ADDR_MX_VELOCITY_P_GAIN, P_GAIN, &dxl_error);
-    dxl_comm_result   = packetHandler->write2ByteTxRx(portHandler, 2, ADDR_MX_VELOCITY_I_GAIN, I_GAIN, &dxl_error);
-    dxl_comm_result   = packetHandler->write4ByteTxRx(portHandler, 2, ADDR_MX_VELOCITY_LIMIT, VELOCITY_LIMIT, &dxl_error);
-    dxl_comm_result   = packetHandler->write1ByteTxRx(portHandler, 2, ADDR_MX_TORQUE_ENABLE, 1, &dxl_error);
-    
-    dxl_comm_result   = packetHandler->write1ByteTxRx(portHandler, 3, ADDR_MX_OPERATING_MODE, 1, &dxl_error);
-    dxl_comm_result   = packetHandler->write2ByteTxRx(portHandler, 3, ADDR_MX_VELOCITY_P_GAIN, P_GAIN, &dxl_error);
-    dxl_comm_result   = packetHandler->write2ByteTxRx(portHandler, 3, ADDR_MX_VELOCITY_I_GAIN, I_GAIN, &dxl_error);
-    dxl_comm_result   = packetHandler->write4ByteTxRx(portHandler, 3, ADDR_MX_VELOCITY_LIMIT, VELOCITY_LIMIT, &dxl_error);
-    dxl_comm_result   = packetHandler->write1ByteTxRx(portHandler, 3, ADDR_MX_TORQUE_ENABLE, 1, &dxl_error);
+	
+	// Set port baudrate
+	portHandler->setBaudRate(BAUDRATE);
+
+    // Set up the motors for velocity control
+    dxl_comm_result = packetHandler->write1ByteTxRx(portHandler, 1, ADDR_MX_OPERATING_MODE, 1, &dxl_error); // Velocity mode
+    dxl_comm_result = packetHandler->write1ByteTxRx(portHandler, 1, ADDR_MX_DRIVE_MODE, 4, &dxl_error); // Acceleration_profile yields the time required to reach goal velocity
+    dxl_comm_result = packetHandler->write4ByteTxRx(portHandler, 1, ADDR_MX_PROFILE_ACCELERATION, nearbyint(ACCELERATION_TIME), &dxl_error); // Acceleration time in [ms] required to reach goal velocity
+    dxl_comm_result = packetHandler->write2ByteTxRx(portHandler, 1, ADDR_MX_VELOCITY_P_GAIN, P_GAIN, &dxl_error);
+    dxl_comm_result = packetHandler->write2ByteTxRx(portHandler, 1, ADDR_MX_VELOCITY_I_GAIN, I_GAIN, &dxl_error);
+    dxl_comm_result = packetHandler->write4ByteTxRx(portHandler, 1, ADDR_MX_VELOCITY_LIMIT, VELOCITY_LIMIT, &dxl_error);
+    dxl_comm_result = packetHandler->write1ByteTxRx(portHandler, 1, ADDR_MX_TORQUE_ENABLE, 1, &dxl_error);
+        
+    dxl_comm_result = packetHandler->write1ByteTxRx(portHandler, 2, ADDR_MX_OPERATING_MODE, 1, &dxl_error);
+    dxl_comm_result = packetHandler->write1ByteTxRx(portHandler, 2, ADDR_MX_DRIVE_MODE, 4, &dxl_error); // Acceleration_profile yields the time required to reach goal velocity
+    dxl_comm_result = packetHandler->write4ByteTxRx(portHandler, 2, ADDR_MX_PROFILE_ACCELERATION, nearbyint(ACCELERATION_TIME), &dxl_error); // Acceleration time in [ms] required to reach goal velocity
+    dxl_comm_result = packetHandler->write2ByteTxRx(portHandler, 2, ADDR_MX_VELOCITY_P_GAIN, P_GAIN, &dxl_error);
+    dxl_comm_result = packetHandler->write2ByteTxRx(portHandler, 2, ADDR_MX_VELOCITY_I_GAIN, I_GAIN, &dxl_error);
+    dxl_comm_result = packetHandler->write4ByteTxRx(portHandler, 2, ADDR_MX_VELOCITY_LIMIT, VELOCITY_LIMIT, &dxl_error);
+    dxl_comm_result = packetHandler->write1ByteTxRx(portHandler, 2, ADDR_MX_TORQUE_ENABLE, 1, &dxl_error);
+
+    dxl_comm_result = packetHandler->write1ByteTxRx(portHandler, 3, ADDR_MX_OPERATING_MODE, 1, &dxl_error);
+    dxl_comm_result = packetHandler->write1ByteTxRx(portHandler, 3, ADDR_MX_DRIVE_MODE, 4, &dxl_error); // Acceleration_profile yields the time required to reach goal velocity
+    dxl_comm_result = packetHandler->write4ByteTxRx(portHandler, 3, ADDR_MX_PROFILE_ACCELERATION, nearbyint(ACCELERATION_TIME), &dxl_error); // Acceleration time in [ms] required to reach goal velocity
+    dxl_comm_result = packetHandler->write2ByteTxRx(portHandler, 3, ADDR_MX_VELOCITY_P_GAIN, P_GAIN, &dxl_error);
+    dxl_comm_result = packetHandler->write2ByteTxRx(portHandler, 3, ADDR_MX_VELOCITY_I_GAIN, I_GAIN, &dxl_error);
+    dxl_comm_result = packetHandler->write4ByteTxRx(portHandler, 3, ADDR_MX_VELOCITY_LIMIT, VELOCITY_LIMIT, &dxl_error);
+    dxl_comm_result = packetHandler->write1ByteTxRx(portHandler, 3, ADDR_MX_TORQUE_ENABLE, 1, &dxl_error);
+
 }
 
 void initialize_dynamixel_PWM_control(double PWM_LIMIT)
@@ -132,6 +158,9 @@ void initialize_dynamixel_PWM_control(double PWM_LIMIT)
         
     // Open COM port for serial communication with the actuators
    portHandler->openPort();
+   
+    // Set port baudrate
+	portHandler->setBaudRate(BAUDRATE);
     
     // Initialize the dxl_error variable
     uint8_t dxl_error = 0;
@@ -160,6 +189,9 @@ void initialize_dynamixel_special_control(double P_GAIN, double I_GAIN, double D
         
     // Open COM port for serial communication with the actuators
    portHandler->openPort();
+   
+    // Set port baudrate
+	portHandler->setBaudRate(BAUDRATE);
     
     // Initialize the dxl_error variable
     uint8_t dxl_error = 0;
@@ -192,6 +224,9 @@ void initialize_dynamixel_current_control(double CURRENT_LIMIT)
         
     // Open COM port for serial communication with the actuators
    portHandler->openPort();
+   
+    // Set port baudrate
+	portHandler->setBaudRate(BAUDRATE);
     
     // Initialize the dxl_error variable
     uint8_t dxl_error = 0;
@@ -225,6 +260,9 @@ void initialize_dynamixel_arm_gripper_control(double P_GAIN_ARM, double I_GAIN_A
         
     // Open COM port for serial communication with the actuators
    portHandler->openPort();
+   
+    // Set port baudrate
+	portHandler->setBaudRate(BAUDRATE);
     
     // Initialize the dxl_error variable
     uint8_t dxl_error = 0;
@@ -338,52 +376,53 @@ void command_dynamixel_position(double JOINT1_POS_RAD, double JOINT2_POS_RAD, do
     
 }
 
-void read_dynamixel_position(double* JOINT1_POS_RAD, double* JOINT2_POS_RAD, double* JOINT3_POS_RAD )
+void read_dynamixel_position(double* JOINT1_POS_RAD, double* JOINT2_POS_RAD, double* JOINT3_POS_RAD, double* JOINT1_SPEED_RAD, double* JOINT2_SPEED_RAD, double* JOINT3_SPEED_RAD)
 {
     
     // Define the transmission failure code
     int dxl_comm_result   = COMM_TX_FAIL;
     bool dxl_addparam_result = false;
+
+	// Syncread present position and velocity
+	dxl_comm_result = groupSyncRead.txRxPacket();
+	
     int32_t dxl1_present_position = 0;
     int32_t dxl2_present_position = 0;
     int32_t dxl3_present_position = 0;
-    
-    dxl_addparam_result = groupBulkRead.addParam(1, ADDR_MX_PRESENT_POSITION, 4);
-    dxl_addparam_result = groupBulkRead.addParam(2, ADDR_MX_PRESENT_POSITION, 4);
-    dxl_addparam_result = groupBulkRead.addParam(3, ADDR_MX_PRESENT_POSITION, 4);
-    
-    dxl_comm_result = groupBulkRead.txRxPacket();
-    dxl1_present_position = groupBulkRead.getData(1, ADDR_MX_PRESENT_POSITION, 4);
-    dxl2_present_position = groupBulkRead.getData(2, ADDR_MX_PRESENT_POSITION, 4);
-    dxl3_present_position = groupBulkRead.getData(3, ADDR_MX_PRESENT_POSITION, 4);
-    
-    if (dxl1_present_position == 0)
-    {
-        *JOINT1_POS_RAD = dxl1_present_position;
-    }
-    else
-    {
-        *JOINT1_POS_RAD = 0.0015344*dxl1_present_position-3.14159;
-    }
-    
-    if (dxl2_present_position == 0)
-    {
-        *JOINT2_POS_RAD = dxl2_present_position;
-    }
-    else
-    {
-        *JOINT2_POS_RAD = 0.0015344*dxl2_present_position-3.14159;
-    }
-    
-    if (dxl3_present_position == 0)
-    {
-        *JOINT3_POS_RAD = dxl3_present_position;
-    }
-    else
-    {
-        *JOINT3_POS_RAD = 0.0015344*dxl3_present_position-3.14159;
-    }
-    groupBulkRead.clearParam();
+    int32_t dxl1_present_speed = 0;
+    int32_t dxl2_present_speed = 0;
+    int32_t dxl3_present_speed = 0;
+
+    // Add motors to the groupSyncRead (for read_dynamixel_position())
+    dxl_addparam_result = groupSyncRead.addParam(1);
+    dxl_addparam_result = groupSyncRead.addParam(2);
+    dxl_addparam_result = groupSyncRead.addParam(3);
+
+	// Get present position values
+    dxl1_present_position = groupSyncRead.getData(1, ADDR_MX_PRESENT_POSITION, 4);
+    dxl2_present_position = groupSyncRead.getData(2, ADDR_MX_PRESENT_POSITION, 4);
+    dxl3_present_position = groupSyncRead.getData(3, ADDR_MX_PRESENT_POSITION, 4);
+    double joint1_wrapped = std::fmod(0.001534363 * dxl1_present_position, 6.283185307179586); // Converting bits to rads, making 0 rad be when the arm joint is extended, and wrapping to [-pi,pi)
+    if (joint1_wrapped < 0)
+        joint1_wrapped += 6.283185307179586;
+    *JOINT1_POS_RAD = joint1_wrapped - 3.14159;
+    double joint2_wrapped = std::fmod(0.001534363 * dxl2_present_position, 6.283185307179586); // Converting bits to rads, making 0 rad be when the arm joint is extended, and wrapping to [-pi,pi)
+    if (joint2_wrapped < 0)
+        joint2_wrapped += 6.283185307179586;
+    *JOINT2_POS_RAD = joint2_wrapped - 3.14159;
+    double joint3_wrapped = std::fmod(0.001534363 * dxl3_present_position, 6.283185307179586); // Converting bits to rads, making 0 rad be when the arm joint is extended, and wrapping to [-pi,pi)
+    if (joint3_wrapped < 0)
+        joint3_wrapped += 6.283185307179586;
+    *JOINT3_POS_RAD = joint3_wrapped - 3.14159;
+
+    // Get present velocity values
+    dxl1_present_speed = groupSyncRead.getData(1, ADDR_MX_PRESENT_SPEED, 4);
+    dxl2_present_speed = groupSyncRead.getData(2, ADDR_MX_PRESENT_SPEED, 4);
+    dxl3_present_speed = groupSyncRead.getData(3, ADDR_MX_PRESENT_SPEED, 4);
+    *JOINT1_SPEED_RAD = 0.023981131017500 * dxl1_present_speed; // Converting bits to rad/s
+    *JOINT2_SPEED_RAD = 0.023981131017500 * dxl2_present_speed; // Converting bits to rad/s
+    *JOINT3_SPEED_RAD = 0.023981131017500 * dxl3_present_speed; // Converting bits to rad/s
+
 }
 
 void read_dynamixel_load(double* JOINT1_LOAD, double* JOINT2_LOAD, double* JOINT3_LOAD )
@@ -405,7 +444,7 @@ void read_dynamixel_load(double* JOINT1_LOAD, double* JOINT2_LOAD, double* JOINT
     groupBulkRead.clearParam();
 }
 
-void command_dynamixel_speed(double JOINT1_SPD_RAD, double JOINT2_SPD_RAD, double JOINT3_SPD_RAD )
+void command_dynamixel_speed(double JOINT1_SPD_RAD, double JOINT2_SPD_RAD, double JOINT3_SPD_RAD)
 {
     // Define the transmission failure code
     int dxl_comm_result   = COMM_TX_FAIL;
@@ -413,47 +452,43 @@ void command_dynamixel_speed(double JOINT1_SPD_RAD, double JOINT2_SPD_RAD, doubl
     uint8_t param_goal_speed_1[4];
     uint8_t param_goal_speed_2[4];
     uint8_t param_goal_speed_3[4];
+	
+	// Initialize the dxl_error variable
+    uint8_t dxl_error = 0;
 
+    // Convert to RPM
     double JOINT1_SPD_RPM = JOINT1_SPD_RAD*9.549296585513702;
     double JOINT2_SPD_RPM = JOINT2_SPD_RAD*9.549296585513702;
     double JOINT3_SPD_RPM = JOINT3_SPD_RAD*9.549296585513702;
+    
+    // Convert to bits (max speed of 234.27 corresponds to bit 1023)
     double JOINT1_SPD_BITS;
     double JOINT2_SPD_BITS;
     double JOINT3_SPD_BITS;
-    
-    if (JOINT1_SPD_RPM <= 0)
-    {
-        JOINT1_SPD_BITS = nearbyint(-8.7721*JOINT1_SPD_RPM + 1024);
-    }
-    if (JOINT2_SPD_RPM <= 0)
-    {
-        JOINT2_SPD_BITS = nearbyint(-8.7721*JOINT2_SPD_RPM + 1024);
-    }
-    if (JOINT3_SPD_RPM <= 0)
-    {
-        JOINT3_SPD_BITS = nearbyint(-8.7721*JOINT3_SPD_RPM + 1024);
-    }
-    
-    if (JOINT1_SPD_RPM > 0)
-    {
-        JOINT1_SPD_BITS = nearbyint(8.7721*JOINT1_SPD_RPM);
-    }
-    if (JOINT2_SPD_RPM > 0)
-    {
-        JOINT2_SPD_BITS = nearbyint(8.7721*JOINT2_SPD_RPM);
-    }
-    if (JOINT3_SPD_RPM > 0)
-    {
-        JOINT3_SPD_BITS = nearbyint(8.7721*JOINT3_SPD_RPM);
-    }
- 
-    
-    // Allocate goal position value into byte array
-    param_goal_speed_1[0] = DXL_LOBYTE(DXL_LOWORD(JOINT1_SPD_BITS));
-    param_goal_speed_1[1] = DXL_HIBYTE(DXL_LOWORD(JOINT1_SPD_BITS));
-    param_goal_speed_1[2] = DXL_LOBYTE(DXL_HIWORD(JOINT1_SPD_BITS));
-    param_goal_speed_1[3] = DXL_HIBYTE(DXL_HIWORD(JOINT1_SPD_BITS));
-    
+    JOINT1_SPD_BITS = nearbyint(JOINT1_SPD_RPM * 4.366756307);
+    JOINT2_SPD_BITS = nearbyint(JOINT2_SPD_RPM * 4.366756307);
+    JOINT3_SPD_BITS = nearbyint(JOINT3_SPD_RPM * 4.366756307);
+	
+	// If any commands are negative, take their two's compliment (for the 4 byte [32 bit] number)
+	if (JOINT1_SPD_BITS < 0)
+	{		
+		JOINT1_SPD_BITS = JOINT1_SPD_BITS + pow(2,32);
+	}
+	if (JOINT2_SPD_BITS < 0)
+	{		
+		JOINT2_SPD_BITS = JOINT2_SPD_BITS + pow(2,32);
+	}
+	if (JOINT3_SPD_BITS < 0)
+	{		
+		JOINT3_SPD_BITS = JOINT3_SPD_BITS + pow(2,32);
+	}
+
+	// Allocate these into the byte array
+	param_goal_speed_1[0] = DXL_LOBYTE(DXL_LOWORD(JOINT1_SPD_BITS));
+	param_goal_speed_1[1] = DXL_HIBYTE(DXL_LOWORD(JOINT1_SPD_BITS));
+	param_goal_speed_1[2] = DXL_LOBYTE(DXL_HIWORD(JOINT1_SPD_BITS));
+	param_goal_speed_1[3] = DXL_HIBYTE(DXL_HIWORD(JOINT1_SPD_BITS));
+
     param_goal_speed_2[0] = DXL_LOBYTE(DXL_LOWORD(JOINT2_SPD_BITS));
     param_goal_speed_2[1] = DXL_HIBYTE(DXL_LOWORD(JOINT2_SPD_BITS));
     param_goal_speed_2[2] = DXL_LOBYTE(DXL_HIWORD(JOINT2_SPD_BITS));
@@ -463,17 +498,16 @@ void command_dynamixel_speed(double JOINT1_SPD_RAD, double JOINT2_SPD_RAD, doubl
     param_goal_speed_3[1] = DXL_HIBYTE(DXL_LOWORD(JOINT3_SPD_BITS));
     param_goal_speed_3[2] = DXL_LOBYTE(DXL_HIWORD(JOINT3_SPD_BITS));
     param_goal_speed_3[3] = DXL_HIBYTE(DXL_HIWORD(JOINT3_SPD_BITS));
-    
-    // Initialize the dxl_error variable
-    uint8_t dxl_error = 0;
-    
-    // Send the raw (0->4096) initial position value.
+    		    
+    // Send the goal velocity command
     dxl_addparam_result = groupBulkWrite.addParam(1, ADDR_MX_GOAL_SPEED, 4, param_goal_speed_1);
     dxl_addparam_result = groupBulkWrite.addParam(2, ADDR_MX_GOAL_SPEED, 4, param_goal_speed_2);
     dxl_addparam_result = groupBulkWrite.addParam(3, ADDR_MX_GOAL_SPEED, 4, param_goal_speed_3);
     
+	// Clean up
     dxl_comm_result = groupBulkWrite.txPacket();
     groupBulkWrite.clearParam();
+		
 }
 
 void command_dynamixel_PWM(double JOINT1_PWM, double JOINT2_PWM, double JOINT3_PWM )


### PR DESCRIPTION
Updated Dynamixel Custom Library to allow for high-speed encoder reads and for improvements to joint position and speed writes. The ReadArm_Position block is renamed to ReadArm_Position_Rates since it now also returns the rates. Note: all reads fail if any motor is disconnected. Angles are in radians and are wrapped to [-pi,pi). The position motion is now smoothed, using the optional MOVE_TIME parameter in the InitializeForPosition block (which sets how many ms the arm should spend moving to the desired location). Set this to 0 for maximum move speed. The MoveArm_Speed block now accepts an "Acceleration Time" parameter, which dictates how long the arm should spend getting to the desired speed (useful for shaping acceleration trajectories). Set Acceleration time to 0 for maximum acceleration.