### PR TITLE
LED renumbering for new PhaseSpace Hardware

### DIFF
--- a/Custom_Library/PhaseSpase_Cameras/PHASESPACE/src/phasespace_functions.cpp
+++ b/Custom_Library/PhaseSpase_Cameras/PHASESPACE/src/phasespace_functions.cpp
@@ -39,14 +39,14 @@ double initialize_phasespace(double platformSelection, double PS_SampleRate)
     
     /* The ID's indicate the location of each LED relative to the center of
        mass for the platform. */
-    tracker_id_RED_7_pos_string = "pos=146.960175,124.9189470,0";
-    tracker_id_RED_1_pos_string = "pos=144.960175,-154.081053,0";
-    tracker_id_RED_3_pos_string = "pos=-133.039825,-153.581053,0";
-    tracker_id_RED_5_pos_string = "pos=-131.539825,124.418947,0";
-    tracker_id_BLACK_15_pos_string = "pos=125.944730,153.415965,0";
-    tracker_id_BLACK_9_pos_string = "pos=124.944730,-125.084035,0";
-    tracker_id_BLACK_11_pos_string = "pos=-153.555270,-124.584035,0";
-    tracker_id_BLACK_13_pos_string = "pos=-151.805270,154.415965,0";
+    tracker_id_RED_5_pos_string = "pos=146.960175,124.9189470,0";
+    tracker_id_RED_3_pos_string = "pos=144.960175,-154.081053,0";
+    tracker_id_RED_1_pos_string = "pos=-133.039825,-153.581053,0";
+    tracker_id_RED_7_pos_string = "pos=-131.539825,124.418947,0";
+    tracker_id_BLACK_13_pos_string = "pos=125.944730,153.415965,0";
+    tracker_id_BLACK_11_pos_string = "pos=124.944730,-125.084035,0";
+    tracker_id_BLACK_9_pos_string = "pos=-153.555270,-124.584035,0";
+    tracker_id_BLACK_15_pos_string = "pos=-151.805270,154.415965,0";
 
 	const std::string myoptions = phaseSpaceOptions; 
     
@@ -63,10 +63,10 @@ double initialize_phasespace(double platformSelection, double PS_SampleRate)
 
     /* Assign markers to the rigid body and indicate their positions
        w.r.t the centre of mass (obtained from calibration text file) */
-    owl.assignMarker(tracker_id_RED, 7, "7", tracker_id_RED_7_pos_string); // top left
-    owl.assignMarker(tracker_id_RED, 1, "1", tracker_id_RED_1_pos_string); // top right
-    owl.assignMarker(tracker_id_RED, 3, "3", tracker_id_RED_3_pos_string); // bottom right
-    owl.assignMarker(tracker_id_RED, 5, "5", tracker_id_RED_5_pos_string); // bottom left 
+    owl.assignMarker(tracker_id_RED, 5, "5", tracker_id_RED_5_pos_string); // top left
+    owl.assignMarker(tracker_id_RED, 3, "3", tracker_id_RED_3_pos_string); // top right
+    owl.assignMarker(tracker_id_RED, 1, "1", tracker_id_RED_1_pos_string); // bottom right
+    owl.assignMarker(tracker_id_RED, 7, "7", tracker_id_RED_7_pos_string); // bottom left 
 
     uint32_t tracker_id_RED_arm = 1;
     owl.createTracker(tracker_id_RED_arm, "rigid", "RED_arm_flexible");
@@ -80,10 +80,10 @@ double initialize_phasespace(double platformSelection, double PS_SampleRate)
 
     /* Assign markers to the rigid body and indicate their positions
        w.r.t the centre of mass (obtained from calibration text file) */
-    owl.assignMarker(tracker_id_BLACK, 15, "15", tracker_id_BLACK_15_pos_string); // top left
-    owl.assignMarker(tracker_id_BLACK, 9,  "9", tracker_id_BLACK_9_pos_string); // top right
-    owl.assignMarker(tracker_id_BLACK, 11, "11", tracker_id_BLACK_11_pos_string); // bottom right
-    owl.assignMarker(tracker_id_BLACK, 13, "13", tracker_id_BLACK_13_pos_string); // bottom left
+    owl.assignMarker(tracker_id_BLACK, 13, "13", tracker_id_BLACK_13_pos_string); // top left
+    owl.assignMarker(tracker_id_BLACK, 11, "11", tracker_id_BLACK_11_pos_string); // top right
+    owl.assignMarker(tracker_id_BLACK, 9,  "9", tracker_id_BLACK_9_pos_string); // bottom right
+    owl.assignMarker(tracker_id_BLACK, 15, "15", tracker_id_BLACK_15_pos_string); // bottom left
 
     /* Start streaming phasespace data. Sending (1) streams data using TCP/IP,
        sending (2) streams data using UDP, and sending (3) streams data using


### PR DESCRIPTION
The new phasespace hardware changed the LED numbers on the platforms, so I updated the phasespace code with new LED numbers. These changes have been tested.

The phasespace calibration and alignment procedure has changed with the new hardware. I will make it clear when I write the wiki article on the topic.