### PR TITLE
fixed termination of dynamixels in speed mode

### DIFF
--- a/Custom_Library/Dynamixel_Actuators/InitializeForSpeed.m
+++ b/Custom_Library/Dynamixel_Actuators/InitializeForSpeed.m
@@ -68,7 +68,9 @@ classdef InitializeForSpeed < matlab.System ...
                 % Place simulation termination code here
             else
                 % Call C-function implementing device termination
-                %coder.ceval('sink_terminate');
+                coder.cinclude('dynamixel_sdk.h');
+                coder.cinclude('dynamixel_functions.h');
+                coder.ceval('terminate_dynamixel');
             end
         end
     end


### PR DESCRIPTION
I forgot to turn off torque to the dynamixels when they were in speed mode. This led the arm to be stiff even when the experiment terminated.